### PR TITLE
Fix duplicate Prometheus target

### DIFF
--- a/configs/prometheus.yml
+++ b/configs/prometheus.yml
@@ -6,4 +6,3 @@ scrape_configs:
   - job_name: "pico_sensors"
     static_configs:
       - targets: ["ip:80"]
-      - targets: ["ip:80"]


### PR DESCRIPTION
## Summary
- deduplicate a duplicate target entry in `configs/prometheus.yml`

## Testing
- `git diff HEAD~1 HEAD`


------
https://chatgpt.com/codex/tasks/task_e_685fe2c4254483278a8d0ce212ec9a79