### PR TITLE
Install GH CLI in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,11 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Install GitHub CLI
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gh
+
       - name: Extract version from tag
         id: version
         run: |


### PR DESCRIPTION
## Summary
- install the GitHub CLI so workflow steps can run `gh` commands

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685fe2b53b208327b1fc1e377e1a89ae