### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,6 +5,9 @@ on:
     branches: [ "main" ]
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/TerrifiedBug/pico-w-prometheus-dht22/security/code-scanning/1](https://github.com/TerrifiedBug/pico-w-prometheus-dht22/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will specify the least privileges required for the workflow to function. Based on the steps in the workflow, it only needs to read the repository contents to check out the code and run tests. Therefore, we will set `contents: read` as the permission.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
